### PR TITLE
Bump FHIRHelpers library

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A library for executing Clinical Quality Language (CQL) expressions asynchronous
 All CQL calculations are executed using the [CQL Execution Engine](https://github.com/cqframework/cql-execution), an open source library that implements the CQL standard.
 
 ### FHIRHelpers
-[FHIRHelpers](https://github.com/cqframework/clinical_quality_language/wiki/FHIRHelpers) is a library that defines functions for converting between FHIR and CQL data types. `cql-worker` includes version `4.0.1` of FHIRHelpers, which is available under an Apache 2.0 License, Copyright 2014 The MITRE Corporation. Other versions of FHIRHelpers can be found [here](https://github.com/cqframework/clinical_quality_language/tree/master/Src/java/quick/src/main/resources/org/hl7/fhir).
+[FHIRHelpers](https://github.com/cqframework/clinical_quality_language/wiki/FHIRHelpers) is a library that defines functions for converting between FHIR and CQL data types. `cql-worker` includes version `4.1.000` of FHIRHelpers, which is available under an Apache 2.0 License, Copyright 2014 The MITRE Corporation. Other versions of FHIRHelpers can be found [here](https://github.com/cqframework/clinical_quality_language/tree/master/Src/java/quick/src/main/resources/org/hl7/fhir).
 
 ### CQL Execution FHIR Data Source
 The [`cql-exec-fhir`](https://github.com/cqframework/cql-exec-fhir) is used to provide a FHIR-based data source for use with the CQL Execution Engine.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "cql-worker",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.2",
+      "name": "cql-worker",
+      "version": "1.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "cql-exec-fhir": "^2.0.0",
@@ -17,8 +18,6 @@
       "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.14.5.tgz",
       "integrity": "sha512-poegjhRvXHWO0EAsnYajwYZuqcz7gyfxwfaecUESxDujrqOivf3zrjFbub8IJkrqEaz3fvJWh001EzxBub54fg==",
       "dependencies": {
-        "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.2",
-        "chokidar": "^3.4.0",
         "commander": "^4.0.1",
         "convert-source-map": "^1.1.0",
         "fs-readdir-recursive": "^1.1.0",
@@ -1501,7 +1500,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -2478,9 +2476,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cql-worker",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "type": "module",
   "description": "A library for executing Clinical Quality Language (CQL) expressions asynchronously via web workers.",
   "main": "main.js",

--- a/src/CqlProcessor.js
+++ b/src/CqlProcessor.js
@@ -1,6 +1,6 @@
 import cql from 'cql-execution';
 import fhir from 'cql-exec-fhir';
-import fhirHelpersJson from './FHIRHelpers-4.0.1.json';
+import fhirHelpersJson from './FHIRHelpers-4.1.000.json';
 
 /**
  * Executes logical expression written in the Clinical Quality Language (CQL) against 

--- a/src/FHIRHelpers-4.1.000.json
+++ b/src/FHIRHelpers-4.1.000.json
@@ -3,22 +3,10 @@
       "annotation" : [ {
          "translatorOptions" : "",
          "type" : "CqlToElmInfo"
-      }, {
-         "type" : "Annotation",
-         "t" : [ {
-            "name" : "author",
-            "value" : "Bryn Rhodes"
-         }, {
-            "name" : "description",
-            "value" : "This library defines functions to convert between FHIR \n data types and CQL system-defined types, as well as functions to support\n FHIRPath implementation. For more information, the FHIRHelpers wiki page:\n https://github.com/cqframework/clinical_quality_language/wiki/FHIRHelpers"
-         }, {
-            "name" : "allowFluent",
-            "value" : "true"
-         } ]
       } ],
       "identifier" : {
          "id" : "FHIRHelpers",
-         "version" : "4.0.1"
+         "version" : "4.1.000"
       },
       "schemaIdentifier" : {
          "id" : "urn:hl7-org:elm",
@@ -43,10 +31,14 @@
             "expression" : {
                "type" : "If",
                "condition" : {
-                  "type" : "IsNull",
+                  "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "As",
                   "operand" : {
-                     "name" : "period",
-                     "type" : "OperandRef"
+                     "type" : "IsNull",
+                     "operand" : {
+                        "name" : "period",
+                        "type" : "OperandRef"
+                     }
                   }
                },
                "then" : {
@@ -65,13 +57,17 @@
                "else" : {
                   "type" : "If",
                   "condition" : {
-                     "type" : "IsNull",
+                     "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "As",
                      "operand" : {
-                        "path" : "start",
-                        "type" : "Property",
-                        "source" : {
-                           "name" : "period",
-                           "type" : "OperandRef"
+                        "type" : "IsNull",
+                        "operand" : {
+                           "path" : "start",
+                           "type" : "Property",
+                           "source" : {
+                              "name" : "period",
+                              "type" : "OperandRef"
+                           }
                         }
                      }
                   },
@@ -979,10 +975,14 @@
             "expression" : {
                "type" : "If",
                "condition" : {
-                  "type" : "IsNull",
+                  "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "As",
                   "operand" : {
-                     "name" : "quantity",
-                     "type" : "OperandRef"
+                     "type" : "IsNull",
+                     "operand" : {
+                        "name" : "quantity",
+                        "type" : "OperandRef"
+                     }
                   }
                },
                "then" : {
@@ -1155,10 +1155,14 @@
             "expression" : {
                "type" : "If",
                "condition" : {
-                  "type" : "IsNull",
+                  "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "As",
                   "operand" : {
-                     "name" : "ratio",
-                     "type" : "OperandRef"
+                     "type" : "IsNull",
+                     "operand" : {
+                        "name" : "ratio",
+                        "type" : "OperandRef"
+                     }
                   }
                },
                "then" : {
@@ -1217,10 +1221,14 @@
             "expression" : {
                "type" : "If",
                "condition" : {
-                  "type" : "IsNull",
+                  "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "As",
                   "operand" : {
-                     "name" : "range",
-                     "type" : "OperandRef"
+                     "type" : "IsNull",
+                     "operand" : {
+                        "name" : "range",
+                        "type" : "OperandRef"
+                     }
                   }
                },
                "then" : {
@@ -1281,10 +1289,14 @@
             "expression" : {
                "type" : "If",
                "condition" : {
-                  "type" : "IsNull",
+                  "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "As",
                   "operand" : {
-                     "name" : "coding",
-                     "type" : "OperandRef"
+                     "type" : "IsNull",
+                     "operand" : {
+                        "name" : "coding",
+                        "type" : "OperandRef"
+                     }
                   }
                },
                "then" : {
@@ -1371,10 +1383,14 @@
             "expression" : {
                "type" : "If",
                "condition" : {
-                  "type" : "IsNull",
+                  "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "As",
                   "operand" : {
-                     "name" : "concept",
-                     "type" : "OperandRef"
+                     "type" : "IsNull",
+                     "operand" : {
+                        "name" : "concept",
+                        "type" : "OperandRef"
+                     }
                   }
                },
                "then" : {
@@ -1446,10 +1462,14 @@
             "expression" : {
                "type" : "If",
                "condition" : {
-                  "type" : "IsNull",
+                  "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "As",
                   "operand" : {
-                     "name" : "reference",
-                     "type" : "OperandRef"
+                     "type" : "IsNull",
+                     "operand" : {
+                        "name" : "reference",
+                        "type" : "OperandRef"
+                     }
                   }
                },
                "then" : {
@@ -1552,7 +1572,45 @@
             "operand" : [ {
                "name" : "resource",
                "operandTypeSpecifier" : {
-                  "name" : "{http://hl7.org/fhir}Resource",
+                  "name" : "{http://hl7.org/fhir}DomainResource",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }, {
+               "name" : "url",
+               "operandTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }
+            } ]
+         }, {
+            "name" : "modifierExtension",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "external" : true,
+            "type" : "FunctionDef",
+            "operand" : [ {
+               "name" : "element",
+               "operandTypeSpecifier" : {
+                  "name" : "{http://hl7.org/fhir}BackboneElement",
+                  "type" : "NamedTypeSpecifier"
+               }
+            }, {
+               "name" : "url",
+               "operandTypeSpecifier" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "NamedTypeSpecifier"
+               }
+            } ]
+         }, {
+            "name" : "modifierExtension",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "external" : true,
+            "type" : "FunctionDef",
+            "operand" : [ {
+               "name" : "resource",
+               "operandTypeSpecifier" : {
+                  "name" : "{http://hl7.org/fhir}DomainResource",
                   "type" : "NamedTypeSpecifier"
                }
             }, {


### PR DESCRIPTION
Upgrade FHIR Helpers version 4.0.1 to version 4.1.000, which is used in [AU 2022 eCQM content](https://github.com/cqframework/ecqm-content-r4-2022/blob/master/input/cql/FHIRHelpers.cql). This change will facilitate the development of new quality measures, and will align with the version update in https://github.com/ccsm-cds-tools/ccsm-cds-with-tests/pull/43.