### PR TITLE
Add evaluate library

### DIFF
--- a/CHANGLOG.md
+++ b/CHANGLOG.md
@@ -1,0 +1,4 @@
+# 1.1.7
+
+Update cql-execution dependency to 3.0.1
+Change evaluateExpression() to asynchronous call

--- a/main.js
+++ b/main.js
@@ -26,7 +26,7 @@ export function initializeCqlWorker(cqlWorker, isNodeJs=false) {
     // If the response is that cqlWorker is still waiting on the patient bundle, 
     // wait 100 ms and resend.
     if (result == 'WAITING_FOR_PATIENT_BUNDLE') {
-      setTimeout( () => cqlWorker.postMessage({expression: expression}), 100);
+      setTimeout( () => cqlWorker.postMessage({__evaluate_library__: 'true'}), 100);
     } else {
       // Try to find this expression in the messageArray
       let executingExpressionIndex = messageArray.map((msg,idx) => {
@@ -100,10 +100,19 @@ export function initializeCqlWorker(cqlWorker, isNodeJs=false) {
     }
   };
 
+  /**
+   * Sends a command to the webworker for to evaluate the entire library.
+   * @returns {boolean} - A dummy return value.
+   */
+  const evaluateLibrary = async function() {
+    return evaluateExpression('__evaluate_library__');
+  };
+
   return [
     setupExecution,
     sendPatientBundle,
-    evaluateExpression
+    evaluateExpression,
+    evaluateLibrary
   ];
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cql-worker",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cql-worker",
-      "version": "1.1.6",
+      "version": "1.1.7",
       "license": "Apache-2.0",
       "dependencies": {
         "cql-exec-fhir": "^2.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "cql-exec-fhir": "^2.1.4",
-        "cql-execution": "^2.4.0"
+        "cql-execution": "^3.0.1"
       }
     },
     "node_modules/@lhncbc/ucum-lhc": {
@@ -46,12 +46,13 @@
       }
     },
     "node_modules/cql-execution": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-2.4.0.tgz",
-      "integrity": "sha512-XgjoPnn3IFys2t2wwi7aT5sXsS+h7/CvqI7dtdDQtSsiK6ePCfnWPT4CRuapiiW3OBrPvqD1oYmvy6X2xvvMlA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.1.tgz",
+      "integrity": "sha512-RC6uxrzvrJImFvyKvYDNLdumCS7nufJobhz5abfV3ZeFxbPR6E2gqJcn0T2KxVh4y40+BqbSGABwgiFTEITCdQ==",
       "dependencies": {
         "@lhncbc/ucum-lhc": "^4.1.3",
-        "luxon": "^1.25.0"
+        "immutable": "^4.1.0",
+        "luxon": "^1.28.1"
       }
     },
     "node_modules/csv-parse": {
@@ -82,6 +83,11 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
       "optional": true
+    },
+    "node_modules/immutable": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
+      "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA=="
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -257,12 +263,13 @@
       }
     },
     "cql-execution": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-2.4.0.tgz",
-      "integrity": "sha512-XgjoPnn3IFys2t2wwi7aT5sXsS+h7/CvqI7dtdDQtSsiK6ePCfnWPT4CRuapiiW3OBrPvqD1oYmvy6X2xvvMlA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.1.tgz",
+      "integrity": "sha512-RC6uxrzvrJImFvyKvYDNLdumCS7nufJobhz5abfV3ZeFxbPR6E2gqJcn0T2KxVh4y40+BqbSGABwgiFTEITCdQ==",
       "requires": {
         "@lhncbc/ucum-lhc": "^4.1.3",
-        "luxon": "^1.25.0"
+        "immutable": "^4.1.0",
+        "luxon": "^1.28.1"
       }
     },
     "csv-parse": {
@@ -293,6 +300,11 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
       "optional": true
+    },
+    "immutable": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
+      "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA=="
     },
     "inherits": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cql-worker",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "type": "module",
   "description": "A library for executing Clinical Quality Language (CQL) expressions asynchronously via web workers or node worker threads.",
   "main": "main.js",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "cql-exec-fhir": "^2.1.4",
-    "cql-execution": "^2.4.0"
+    "cql-execution": "^3.0.1"
   }
 }

--- a/src/CqlProcessor.js
+++ b/src/CqlProcessor.js
@@ -1,6 +1,6 @@
-import cql from 'cql-execution';
-import fhir from 'cql-exec-fhir';
-import fhirHelpersJson from './FHIRHelpers-4.0.1.json.js';
+import cql from "cql-execution";
+import fhir from "cql-exec-fhir";
+import fhirHelpersJson from "./FHIRHelpers-4.0.1.json.js";
 
 /**
  * Executes logical expression written in the Clinical Quality Language (CQL) against
@@ -14,15 +14,24 @@ export default class CqlProcessor {
    * @param {object} parameters - Key:value pairs of parameters for the CQL library
    * @param {object} elmJsonDependencies - Libraries referenced from within elmJson.
    */
-  constructor(elmJson, valueSetJson, parameters=null, elmJsonDependencies = {}) {
+  constructor(
+    elmJson,
+    valueSetJson,
+    parameters = null,
+    elmJsonDependencies = {}
+  ) {
     this.patientSource = fhir.PatientSource.FHIRv401();
-    this.repository  = new cql.Repository({
-      'FHIRHelpers': fhirHelpersJson,
-      ...elmJsonDependencies
+    this.repository = new cql.Repository({
+      FHIRHelpers: fhirHelpersJson,
+      ...elmJsonDependencies,
     });
     this.library = new cql.Library(elmJson, this.repository);
     this.codeService = new cql.CodeService(valueSetJson);
-    this.executor = new cql.Executor(this.library, this.codeService, parameters);
+    this.executor = new cql.Executor(
+      this.library,
+      this.codeService,
+      parameters
+    );
   }
 
   /**
@@ -32,9 +41,9 @@ export default class CqlProcessor {
   loadBundle(patientBundle) {
     this.patientSource.reset(); // necessary to avoid memory leaks
     this.patientSource.loadBundles([patientBundle]);
-    this.patientID = this.patientSource._bundles[0].entry.
-      filter(resrc => resrc.resource.resourceType == 'Patient').
-      map(resrc => resrc.resource.id);
+    this.patientID = this.patientSource._bundles[0].entry
+      .filter((resrc) => resrc.resource.resourceType == "Patient")
+      .map((resrc) => resrc.resource.id);
   }
 
   /**
@@ -46,9 +55,27 @@ export default class CqlProcessor {
   async evaluateExpression(expr) {
     // Only try to evaluate an expression if we have a patient bundle loaded.
     if (this.patientSource._bundles && this.patientSource._bundles.length > 0) {
-      let results = await this.executor.exec_expression(expr, this.patientSource);
-      this.patientSource._index = 0; // HACK: rewind the patient source
-      return results.patientResults[this.patientID][expr];
+      let results;
+      if (expr == "__evaluate_library__") {
+        results = await this.executor.exec(this.patientSource);
+        return results.patientResults[this.patientID];
+      } else {
+        results = await this.executor.exec_expression(
+          expr,
+          this.patientSource
+        );
+        this.patientSource._index = 0; // HACK: rewind the patient source
+        return results.patientResults[this.patientID][expr];
+      }
     } else return null;
+  }
+
+  /**
+   * Evaluate an expression from the CQL library represented by elmJson against
+   * the patient bundle.
+   * @returns {object} results - The results from executing the expression
+   */
+  async evaluateLibrary() {
+    return this.evaluateExpression("__evaluate_library__");
   }
 }

--- a/src/CqlProcessor.js
+++ b/src/CqlProcessor.js
@@ -3,13 +3,13 @@ import fhir from 'cql-exec-fhir';
 import fhirHelpersJson from './FHIRHelpers-4.0.1.json.js';
 
 /**
- * Executes logical expression written in the Clinical Quality Language (CQL) against 
- * a bundle of patient data formatted as FHIR resources. 
+ * Executes logical expression written in the Clinical Quality Language (CQL) against
+ * a bundle of patient data formatted as FHIR resources.
  */
 export default class CqlProcessor {
   /**
    * Create a CQL Processor.
-   * @param {object} elmJson - The CQL library formatted in ELM JSON 
+   * @param {object} elmJson - The CQL library formatted in ELM JSON
    * @param {object} valueSetJson - A value set cache which maps codes to clinical concepts
    * @param {object} parameters - Key:value pairs of parameters for the CQL library
    * @param {object} elmJsonDependencies - Libraries referenced from within elmJson.
@@ -38,15 +38,15 @@ export default class CqlProcessor {
   }
 
   /**
-   * Evaluate an expression from the CQL library represented by elmJson against 
+   * Evaluate an expression from the CQL library represented by elmJson against
    * the patient bundle.
    * @param {string} expr - The name of an expression from elmJson
    * @returns {object} results - The results from executing the expression
    */
-  evaluateExpression(expr) {
+  async evaluateExpression(expr) {
     // Only try to evaluate an expression if we have a patient bundle loaded.
     if (this.patientSource._bundles && this.patientSource._bundles.length > 0) {
-      let results = this.executor.exec_expression(expr, this.patientSource);
+      let results = await this.executor.exec_expression(expr, this.patientSource);
       this.patientSource._index = 0; // HACK: rewind the patient source
       return results.patientResults[this.patientID][expr];
     } else return null;

--- a/src/cql-worker-thread.js
+++ b/src/cql-worker-thread.js
@@ -10,12 +10,12 @@ var processor = {};
  * 1. elmJson & valueSetJon - Logic and code libraries for initial setup
  * 2. patientBundle - An initial or updated patient bundle
  * 3. expression - A logical expression needing to be evaluated
- * It is assumed that at least initially messages are sent in that order. For 
- * the third type, if an expression can be evaluated, the result is sent back 
+ * It is assumed that at least initially messages are sent in that order. For
+ * the third type, if an expression can be evaluated, the result is sent back
  * as a message.
  * @param {object} rx - The message object being sent
  */
-parentPort.onmessage = function(rx) {
+parentPort.onmessage = async function(rx) {
   let elmJson;
   let valueSetJson;
   let patientBundle;
@@ -23,12 +23,12 @@ parentPort.onmessage = function(rx) {
   let parameters;
   let elmJsonDependencies;
 
-  // For efficiency, first check if this is an expression message, since that is 
+  // For efficiency, first check if this is an expression message, since that is
   // the type called most often.
   if ((expression = rx.data.expression) != null) {
     let tx;
     if (processor.patientSource._bundles.length > 0) {
-      let result = processor.evaluateExpression(expression);
+      let result = await processor.evaluateExpression(expression);
       tx = {
         expression: expression,
         result: result
@@ -45,7 +45,7 @@ parentPort.onmessage = function(rx) {
     // If the message contains a patient bundle, load it.
     processor.loadBundle(patientBundle);
   } else if ((elmJson = rx.data.elmJson) != null && (valueSetJson = rx.data.valueSetJson) != null) { // TODO: Allow empty value sets and check elm dependencies
-    // If the message contains translated CQL (ELM JSON), use it to create a new 
+    // If the message contains translated CQL (ELM JSON), use it to create a new
     // CQL Processor object.
     parameters = rx.data.parameters;
     elmJsonDependencies = rx.data.elmJsonDependencies;

--- a/src/cql.worker.js
+++ b/src/cql.worker.js
@@ -23,10 +23,16 @@ onmessage = async function(rx) {
 
   // For efficiency, first check if this is an expression message, since that is
   // the type called most often.
-  if ((expression = rx.data.expression) != null) {
-    let tx;
+
+   if ((expression = rx.data.expression) != null) {
+
+    let tx,result;
     if (processor.patientSource._bundles.length > 0) {
-      let result = await processor.evaluateExpression(expression);
+      if(expression == '__evaluate_library__'){
+        result = await processor.evaluateLibrary();
+      }else{
+        result = await processor.evaluateExpression(expression);
+      }
       tx = {
         expression: expression,
         result: result

--- a/src/cql.worker.js
+++ b/src/cql.worker.js
@@ -8,12 +8,12 @@ var processor = {};
  * 1. elmJson & valueSetJon - Logic and code libraries for initial setup
  * 2. patientBundle - An initial or updated patient bundle
  * 3. expression - A logical expression needing to be evaluated
- * It is assumed that at least initially messages are sent in that order. For 
- * the third type, if an expression can be evaluated, the result is sent back 
+ * It is assumed that at least initially messages are sent in that order. For
+ * the third type, if an expression can be evaluated, the result is sent back
  * as a message.
  * @param {object} rx - The message object being sent
  */
-onmessage = function(rx) {
+onmessage = async function(rx) {
   let elmJson;
   let valueSetJson;
   let patientBundle;
@@ -21,12 +21,12 @@ onmessage = function(rx) {
   let parameters;
   let elmJsonDependencies;
 
-  // For efficiency, first check if this is an expression message, since that is 
+  // For efficiency, first check if this is an expression message, since that is
   // the type called most often.
   if ((expression = rx.data.expression) != null) {
     let tx;
     if (processor.patientSource._bundles.length > 0) {
-      let result = processor.evaluateExpression(expression);
+      let result = await processor.evaluateExpression(expression);
       tx = {
         expression: expression,
         result: result
@@ -43,7 +43,7 @@ onmessage = function(rx) {
     // If the message contains a patient bundle, load it.
     processor.loadBundle(patientBundle);
   } else if ((elmJson = rx.data.elmJson) != null && (valueSetJson = rx.data.valueSetJson) != null) { // TODO: Allow empty value sets and check elm dependencies
-    // If the message contains translated CQL (ELM JSON), use it to create a new 
+    // If the message contains translated CQL (ELM JSON), use it to create a new
     // CQL Processor object.
     parameters = rx.data.parameters;
     elmJsonDependencies = rx.data.elmJsonDependencies;


### PR DESCRIPTION
This PR adds the ability to evaluate an entire CQL library and return the results back to the caller.  It does this by utilizing the existing processing framework in place and uses a specific __evaluate_library__  expression to evaluate the library. 